### PR TITLE
Add Fedora (DNF) package setup

### DIFF
--- a/.config/dnf/copr.txt
+++ b/.config/dnf/copr.txt
@@ -1,0 +1,53 @@
+# COPR repositories to enable (similar to Homebrew taps)
+# Format: owner/repo
+
+# Charm tools (gum, etc.)
+charmbracelet/gum
+
+# Helix editor
+helix-editor/helix
+
+# Lazygit and Lazydocker
+atim/lazygit
+
+# Mise (asdf rust clone)
+mise/mise
+
+# Eza (modern ls replacement)
+varlad/eza
+
+# Zoxide (shell navigation)
+atim/zoxide
+
+# GitHub CLI
+gh-cli/gh
+
+# Docker tools
+imtherealk/dive
+
+# Typst (markup-based typesetting)
+phryneas/typst
+
+# Procs (modern ps replacement)
+deltacopy/procs
+
+# Act (run GitHub Actions locally)
+rubemlrm/act
+
+# Deno runtime
+phryneas/deno
+
+# Git Delta (syntax-highlighting pager)
+guyuefangyuan/git-delta
+
+# DuckDB
+adrgomez/duckdb
+
+# Ollama (LLM runner)
+atim/ollama
+
+# Ghostty terminal
+pgdev/ghostty
+
+# VSCodium
+zeno/vscodium

--- a/.config/dnf/flatpak.txt
+++ b/.config/dnf/flatpak.txt
@@ -1,0 +1,63 @@
+# Flatpak packages (equivalent to Homebrew casks)
+# Format: app-id  # Description
+
+# Password manager
+com.onepassword.OnePassword  # Password manager that keeps all passwords secure behind one password
+
+# Web browsers
+com.brave.Browser  # Web browser focusing on privacy
+org.mozilla.firefox  # Web browser (stable)
+# Note: Firefox Developer Edition and Nightly available via Mozilla's Flatpak beta repo
+org.chromium.Chromium  # Google Chromium (ungoogled alternatives available)
+
+# Communication
+com.discordapp.Discord  # Voice and text chat software
+im.element.Element  # Matrix collaboration client
+org.signal.Signal  # Instant messaging application focusing on security
+com.slack.Slack  # Team communication and collaboration software
+us.zoom.Zoom  # Video communication and virtual meeting platform
+
+# Design
+com.figma.Figma  # Collaborative team software (unofficial Flatpak)
+
+# Media players
+io.github.AKotchenko.FreeTubeGtk  # YouTube player focusing on privacy
+io.mpv.Mpv  # Free and open-source media player (alternative to IINA)
+org.videolan.VLC  # VLC media player (another alternative to IINA)
+
+# Productivity
+md.obsidian.Obsidian  # Knowledge base that works on top of a local folder of plain text Markdown files
+org.libreoffice.LibreOffice  # Free cross-platform office suite
+
+# RSS reader
+org.gnome.FeedReader  # RSS reader (alternative to NetNewsWire)
+io.gitlab.news_flash.NewsFlash  # Modern RSS reader (better alternative to NetNewsWire)
+
+# Development
+com.jetbrains.IntelliJ-IDEA-Community  # Java IDE by JetBrains (use -Ultimate for paid version)
+com.vscodium.codium  # Binary releases of VS Code without MS branding/telemetry
+
+# Markdown editor
+org.gnome.gitlab.somas.Apostrophe  # Markdown editor (alternative to MarkEdit)
+com.github.marktext.marktext  # Simple and elegant markdown editor
+
+# Application launcher
+com.github.Ulauncher.Ulauncher  # Control your tools with a few keystrokes (alternative to Raycast)
+
+# Screen recording
+# Cap is not available on Linux - alternatives below
+io.github.seadve.Kooha  # Screen recording software
+org.kde.kdenlive  # Video editor with screen capture
+
+# PDF viewer
+org.gnome.Evince  # Document viewer (PDF, etc.)
+# Adobe Acrobat Reader not available on Linux - use Evince, Okular, or Firefox
+
+# VPN
+# NordVPN - install via their official repo/script, no Flatpak
+
+# Font viewer
+org.gnome.font-viewer  # Font viewer (simpler than FontGoggles)
+
+# Security monitoring (alternative to Micro Snitch)
+# Linux has different security models - use your DE's privacy settings

--- a/.config/dnf/install.sh
+++ b/.config/dnf/install.sh
@@ -1,0 +1,445 @@
+#!/usr/bin/env bash
+#
+# Fedora Package Installer
+# Equivalent to `brew bundle` for Fedora
+#
+# Usage: ./install.sh [options]
+#   --all         Install everything (default)
+#   --copr        Enable COPR repositories only
+#   --packages    Install DNF packages only
+#   --flatpak     Install Flatpak packages only
+#   --manual      Install manual packages only
+#   --dry-run     Show what would be installed without installing
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DRY_RUN=false
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+log_info() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+log_success() {
+    echo -e "${GREEN}[OK]${NC} $1"
+}
+
+log_warning() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+run_cmd() {
+    if [[ "$DRY_RUN" == "true" ]]; then
+        echo "  Would run: $*"
+    else
+        "$@"
+    fi
+}
+
+# Check if running on Fedora
+check_fedora() {
+    if [[ ! -f /etc/fedora-release ]]; then
+        log_error "This script is designed for Fedora Linux"
+        exit 1
+    fi
+    log_info "Detected Fedora $(cat /etc/fedora-release)"
+}
+
+# Enable RPM Fusion repositories (needed for ffmpeg with full codecs)
+enable_rpmfusion() {
+    log_info "Enabling RPM Fusion repositories..."
+    if ! rpm -q rpmfusion-free-release &>/dev/null; then
+        run_cmd sudo dnf install -y \
+            "https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm" \
+            "https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm"
+        log_success "RPM Fusion enabled"
+    else
+        log_info "RPM Fusion already enabled"
+    fi
+}
+
+# Enable COPR repositories
+enable_copr_repos() {
+    log_info "Enabling COPR repositories..."
+
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        # Skip comments and empty lines
+        [[ "$line" =~ ^[[:space:]]*# ]] && continue
+        [[ -z "${line// }" ]] && continue
+
+        repo=$(echo "$line" | awk '{print $1}')
+        if [[ -n "$repo" ]]; then
+            log_info "Enabling COPR: $repo"
+            run_cmd sudo dnf copr enable -y "$repo" || log_warning "Failed to enable $repo"
+        fi
+    done < "$SCRIPT_DIR/copr.txt"
+
+    log_success "COPR repositories enabled"
+}
+
+# Install DNF packages
+install_dnf_packages() {
+    log_info "Installing DNF packages..."
+
+    local packages=()
+
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        # Skip comments and empty lines
+        [[ "$line" =~ ^[[:space:]]*# ]] && continue
+        [[ -z "${line// }" ]] && continue
+
+        # Extract package name (before any # comment)
+        pkg=$(echo "$line" | awk '{print $1}')
+        if [[ -n "$pkg" ]]; then
+            packages+=("$pkg")
+        fi
+    done < "$SCRIPT_DIR/packages.txt"
+
+    if [[ ${#packages[@]} -gt 0 ]]; then
+        log_info "Installing ${#packages[@]} packages..."
+        run_cmd sudo dnf install -y "${packages[@]}" || true
+        log_success "DNF packages installed"
+    fi
+}
+
+# Setup Flatpak and install packages
+install_flatpak_packages() {
+    log_info "Setting up Flatpak..."
+
+    # Ensure Flatpak is installed
+    if ! command -v flatpak &>/dev/null; then
+        run_cmd sudo dnf install -y flatpak
+    fi
+
+    # Add Flathub repository
+    if ! flatpak remotes | grep -q flathub; then
+        run_cmd flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+        log_success "Flathub repository added"
+    fi
+
+    log_info "Installing Flatpak packages..."
+
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        # Skip comments and empty lines
+        [[ "$line" =~ ^[[:space:]]*# ]] && continue
+        [[ -z "${line// }" ]] && continue
+
+        # Extract app ID (before any # comment)
+        app=$(echo "$line" | awk '{print $1}')
+        if [[ -n "$app" ]]; then
+            log_info "Installing Flatpak: $app"
+            run_cmd flatpak install -y flathub "$app" || log_warning "Failed to install $app"
+        fi
+    done < "$SCRIPT_DIR/flatpak.txt"
+
+    log_success "Flatpak packages installed"
+}
+
+# Install packages that require manual installation
+install_manual_packages() {
+    log_info "Installing packages that require manual installation..."
+
+    # Bun
+    if ! command -v bun &>/dev/null; then
+        log_info "Installing Bun..."
+        run_cmd curl -fsSL https://bun.sh/install | bash
+    else
+        log_info "Bun already installed"
+    fi
+
+    # Flyctl
+    if ! command -v flyctl &>/dev/null; then
+        log_info "Installing flyctl..."
+        run_cmd curl -L https://fly.io/install.sh | sh
+    else
+        log_info "flyctl already installed"
+    fi
+
+    # Zinit
+    if [[ ! -d "${ZINIT_HOME:-$HOME/.local/share/zinit}" ]]; then
+        log_info "Installing zinit..."
+        run_cmd bash -c "$(curl --fail --show-error --silent --location https://raw.githubusercontent.com/zdharma-continuum/zinit/HEAD/scripts/install.sh)"
+    else
+        log_info "zinit already installed"
+    fi
+
+    # Git-town
+    if ! command -v git-town &>/dev/null; then
+        log_info "Installing git-town..."
+        local version
+        version=$(curl -s https://api.github.com/repos/git-town/git-town/releases/latest | grep tag_name | cut -d '"' -f 4)
+        run_cmd curl -L "https://github.com/git-town/git-town/releases/download/${version}/git-town_linux_amd64.tar.gz" | tar xz -C /tmp
+        run_cmd sudo mv /tmp/git-town /usr/local/bin/
+    else
+        log_info "git-town already installed"
+    fi
+
+    # AWS Vault
+    if ! command -v aws-vault &>/dev/null; then
+        log_info "Installing aws-vault..."
+        local version
+        version=$(curl -s https://api.github.com/repos/99designs/aws-vault/releases/latest | grep tag_name | cut -d '"' -f 4)
+        run_cmd sudo curl -L "https://github.com/99designs/aws-vault/releases/download/${version}/aws-vault-linux-amd64" -o /usr/local/bin/aws-vault
+        run_cmd sudo chmod +x /usr/local/bin/aws-vault
+    else
+        log_info "aws-vault already installed"
+    fi
+
+    # dprint
+    if ! command -v dprint &>/dev/null; then
+        log_info "Installing dprint..."
+        run_cmd curl -fsSL https://dprint.dev/install.sh | sh
+    else
+        log_info "dprint already installed"
+    fi
+
+    # Vale
+    if ! command -v vale &>/dev/null; then
+        log_info "Installing vale..."
+        local version
+        version=$(curl -s https://api.github.com/repos/errata-ai/vale/releases/latest | grep tag_name | cut -d '"' -f 4)
+        run_cmd curl -L "https://github.com/errata-ai/vale/releases/download/${version}/vale_${version#v}_Linux_64-bit.tar.gz" | tar xz -C /tmp
+        run_cmd sudo mv /tmp/vale /usr/local/bin/
+    else
+        log_info "vale already installed"
+    fi
+
+    # Lazydocker
+    if ! command -v lazydocker &>/dev/null; then
+        log_info "Installing lazydocker..."
+        run_cmd curl https://raw.githubusercontent.com/jesseduffield/lazydocker/master/scripts/install_update_linux.sh | bash
+    else
+        log_info "lazydocker already installed"
+    fi
+
+    # Turso CLI
+    if ! command -v turso &>/dev/null; then
+        log_info "Installing Turso CLI..."
+        run_cmd curl -sSfL https://get.tur.so/install.sh | bash
+    else
+        log_info "Turso CLI already installed"
+    fi
+
+    # Fastly CLI
+    if ! command -v fastly &>/dev/null; then
+        log_info "Installing Fastly CLI..."
+        local version
+        version=$(curl -s https://api.github.com/repos/fastly/cli/releases/latest | grep tag_name | cut -d '"' -f 4)
+        run_cmd curl -L "https://github.com/fastly/cli/releases/download/${version}/fastly_${version#v}_linux_amd64.tar.gz" | tar xz -C /tmp
+        run_cmd sudo mv /tmp/fastly /usr/local/bin/
+    else
+        log_info "Fastly CLI already installed"
+    fi
+
+    # IPinfo CLI
+    if ! command -v ipinfo &>/dev/null; then
+        log_info "Installing IPinfo CLI..."
+        run_cmd curl -Ls https://github.com/ipinfo/cli/releases/download/ipinfo-3.3.1/ipinfo_3.3.1_linux_amd64.tar.gz | tar xz -C /tmp
+        run_cmd sudo mv /tmp/ipinfo_3.3.1_linux_amd64 /usr/local/bin/ipinfo
+    else
+        log_info "IPinfo CLI already installed"
+    fi
+
+    # qsv
+    if ! command -v qsv &>/dev/null; then
+        log_info "Installing qsv..."
+        local version
+        version=$(curl -s https://api.github.com/repos/jqnatividad/qsv/releases/latest | grep tag_name | cut -d '"' -f 4)
+        run_cmd curl -L "https://github.com/jqnatividad/qsv/releases/download/${version}/qsv-${version}-x86_64-unknown-linux-gnu.zip" -o /tmp/qsv.zip
+        run_cmd unzip -o /tmp/qsv.zip -d /tmp/qsv
+        run_cmd sudo mv /tmp/qsv/qsv* /usr/local/bin/
+        run_cmd rm -rf /tmp/qsv /tmp/qsv.zip
+    else
+        log_info "qsv already installed"
+    fi
+
+    # NPM global packages (requires Node.js via mise or system)
+    if command -v npm &>/dev/null; then
+        log_info "Installing npm global packages..."
+        run_cmd npm install -g cfonts fx || log_warning "Failed to install npm packages"
+    else
+        log_warning "npm not found - skipping cfonts and fx installation"
+        log_info "Install Node.js via mise, then run: npm install -g cfonts fx"
+    fi
+
+    # Cargo packages (requires Rust via mise or system)
+    if command -v cargo &>/dev/null; then
+        log_info "Installing cargo packages..."
+        run_cmd cargo install htmlq icann-rdap sniffnet || log_warning "Failed to install some cargo packages"
+    else
+        log_warning "cargo not found - skipping htmlq, icann-rdap, sniffnet installation"
+        log_info "Install Rust via mise, then run: cargo install htmlq icann-rdap sniffnet"
+    fi
+
+    # q DNS tool
+    if ! command -v q &>/dev/null; then
+        log_info "Installing q (DNS tool)..."
+        local version
+        version=$(curl -s https://api.github.com/repos/natesales/q/releases/latest | grep tag_name | cut -d '"' -f 4)
+        run_cmd curl -L "https://github.com/natesales/q/releases/download/${version}/q_${version#v}_linux_amd64.tar.gz" | tar xz -C /tmp
+        run_cmd sudo mv /tmp/q /usr/local/bin/
+    else
+        log_info "q already installed"
+    fi
+
+    # sq data wrangler
+    if ! command -v sq &>/dev/null; then
+        log_info "Installing sq..."
+        local version
+        version=$(curl -s https://api.github.com/repos/neilotoole/sq/releases/latest | grep tag_name | cut -d '"' -f 4)
+        run_cmd curl -L "https://github.com/neilotoole/sq/releases/download/${version}/sq_linux_amd64.tar.gz" | tar xz -C /tmp
+        run_cmd sudo mv /tmp/sq /usr/local/bin/
+    else
+        log_info "sq already installed"
+    fi
+
+    log_success "Manual packages installed"
+}
+
+# Install VSCode/VSCodium extensions
+install_vscode_extensions() {
+    log_info "Installing VSCode/VSCodium extensions..."
+
+    local cmd=""
+    if command -v codium &>/dev/null; then
+        cmd="codium"
+    elif command -v code &>/dev/null; then
+        cmd="code"
+    else
+        log_warning "VSCodium/VSCode not found, skipping extensions"
+        return
+    fi
+
+    local extensions=(
+        "orta.vscode-jest"
+        "redhat.vscode-yaml"
+        "vue.volar"
+    )
+
+    for ext in "${extensions[@]}"; do
+        log_info "Installing extension: $ext"
+        run_cmd "$cmd" --install-extension "$ext" || log_warning "Failed to install $ext"
+    done
+
+    log_success "VSCode extensions installed"
+}
+
+# Install Go packages
+install_go_packages() {
+    if ! command -v go &>/dev/null; then
+        log_warning "Go not found, skipping Go packages"
+        log_info "Install Go via mise, then run this script again with --manual"
+        return
+    fi
+
+    log_info "Installing Go packages..."
+    run_cmd go install cmd/go@latest || true
+    run_cmd go install cmd/gofmt@latest || true
+    log_success "Go packages installed"
+}
+
+# Print summary
+print_summary() {
+    echo ""
+    echo "============================================"
+    log_success "Installation complete!"
+    echo "============================================"
+    echo ""
+    echo "Post-installation notes:"
+    echo "  1. Restart your shell or run: source ~/.zshrc"
+    echo "  2. Set up mise: mise install"
+    echo "  3. Configure GPG: gpg --full-generate-key"
+    echo "  4. Log in to services: gh auth login, flyctl auth login, etc."
+    echo ""
+    echo "Some packages may need additional configuration:"
+    echo "  - Tailscale: sudo tailscale up"
+    echo "  - Ollama: ollama pull <model>"
+    echo "  - Redis: sudo systemctl enable --now redis"
+    echo "  - PostgreSQL: sudo systemctl enable --now postgresql"
+    echo ""
+}
+
+# Main installation
+main() {
+    local install_copr=false
+    local install_packages=false
+    local install_flatpak=false
+    local install_manual=false
+    local install_all=true
+
+    # Parse arguments
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --copr)
+                install_copr=true
+                install_all=false
+                ;;
+            --packages)
+                install_packages=true
+                install_all=false
+                ;;
+            --flatpak)
+                install_flatpak=true
+                install_all=false
+                ;;
+            --manual)
+                install_manual=true
+                install_all=false
+                ;;
+            --dry-run)
+                DRY_RUN=true
+                log_warning "Dry run mode - no changes will be made"
+                ;;
+            --all)
+                install_all=true
+                ;;
+            -h|--help)
+                echo "Usage: $0 [options]"
+                echo "  --all         Install everything (default)"
+                echo "  --copr        Enable COPR repositories only"
+                echo "  --packages    Install DNF packages only"
+                echo "  --flatpak     Install Flatpak packages only"
+                echo "  --manual      Install manual packages only"
+                echo "  --dry-run     Show what would be installed"
+                exit 0
+                ;;
+            *)
+                log_error "Unknown option: $1"
+                exit 1
+                ;;
+        esac
+        shift
+    done
+
+    check_fedora
+
+    if [[ "$install_all" == "true" ]]; then
+        enable_rpmfusion
+        enable_copr_repos
+        install_dnf_packages
+        install_flatpak_packages
+        install_manual_packages
+        install_vscode_extensions
+        install_go_packages
+        print_summary
+    else
+        [[ "$install_copr" == "true" ]] && { enable_rpmfusion; enable_copr_repos; }
+        [[ "$install_packages" == "true" ]] && install_dnf_packages
+        [[ "$install_flatpak" == "true" ]] && install_flatpak_packages
+        [[ "$install_manual" == "true" ]] && { install_manual_packages; install_vscode_extensions; install_go_packages; }
+    fi
+}
+
+main "$@"

--- a/.config/dnf/manual.txt
+++ b/.config/dnf/manual.txt
@@ -1,0 +1,51 @@
+# Packages requiring manual installation
+# These are not available in DNF, COPR, or Flatpak
+# The install script will attempt to install these via their official methods
+
+# AWS tools
+aws-vault  # Securely store and access AWS credentials - https://github.com/99designs/aws-vault
+
+# JavaScript/TypeScript
+bun  # Incredibly fast JavaScript runtime - https://bun.sh
+
+# CLI tools
+cfonts  # Sexy ANSI fonts for the console - npm install -g cfonts
+dprint  # Pluggable code formatting platform - https://dprint.dev
+fx  # Terminal JSON viewer - npm install -g fx or go install
+htmlq  # Uses CSS selectors to extract content from HTML - cargo install htmlq
+qsv  # Ultra-fast CSV data-wrangling toolkit - https://github.com/jqnatividad/qsv
+
+# DNS/Network tools
+q  # DNS client with DoH/DoT support - https://github.com/natesales/q
+icann-rdap  # RDAP client - cargo install icann-rdap
+ipinfo-cli  # Official CLI for IPinfo API - https://github.com/ipinfo/cli
+
+# Cloud/Platform CLIs
+flyctl  # Command-line tools for fly.io - https://fly.io/docs/hands-on/install-flyctl/
+fastly  # CLI for Fastly platform - https://github.com/fastly/cli
+
+# Database tools
+sqld  # libSQL server - https://github.com/tursodatabase/libsql
+turso  # Turso CLI - https://docs.turso.tech/cli/installation
+sq  # sq data wrangler - https://sq.io
+
+# Git tools
+git-town  # High-level CLI for Git - https://www.git-town.com
+
+# Prose/writing
+vale  # Syntax-aware linter for prose - https://vale.sh
+
+# Docker tools
+lazydocker  # Lazier way to manage docker - https://github.com/jesseduffield/lazydocker
+
+# AI/Dev tools
+opencode  # AI coding agent for terminal - https://github.com/sst/opencode
+
+# Zsh
+zinit  # Zsh plugin manager - https://github.com/zdharma-continuum/zinit
+
+# Network monitoring
+sniffnet  # Cross-platform network monitor - cargo install sniffnet or https://sniffnet.net
+
+# Fonts
+font-sf-mono-nerd-font-ligaturized  # Nerd font - manual download from GitHub

--- a/.config/dnf/packages.txt
+++ b/.config/dnf/packages.txt
@@ -1,0 +1,153 @@
+# DNF packages (equivalent to Homebrew formulae)
+# Lines starting with # are comments
+# Format: package-name  # Description
+
+# Core utilities and libraries
+openssl  # Cryptography and SSL/TLS Toolkit
+libyaml-devel  # YAML Parser
+sqlite  # Command-line interface for SQLite
+tree  # Display directories as trees
+
+# Configuration management
+ansible  # Automate deployment, configuration, and upgrading
+
+# Media and image processing
+libjxl  # JPEG XL image format
+ImageMagick  # Tools and libraries to manipulate images
+harfbuzz  # OpenType text shaping engine
+tesseract  # OCR (Optical Character Recognition) engine
+ffmpeg-free  # Play, record, convert, and stream audio and video (use ffmpeg from RPM Fusion for full codec support)
+woff2  # Web Open Font File utilities
+
+# Download tools
+aria2  # Download with resuming and segmented downloading
+
+# Build tools
+autoconf  # Automatic configure script builder
+cmake  # Cross-platform make
+llvm  # Next-gen compiler infrastructure
+
+# AWS tools
+awscli2  # Official Amazon AWS command-line interface
+
+# Modern CLI replacements
+bat  # Clone of cat(1) with syntax highlighting and Git integration
+eza  # Modern, maintained replacement for ls (from COPR)
+fd-find  # Simple, fast and user-friendly alternative to find
+ripgrep  # Search tool like grep and The Silver Searcher
+duf  # Disk Usage/Free Utility - a better 'df' alternative
+procs  # Modern replacement for ps written in Rust (from COPR)
+zoxide  # Shell extension to navigate your filesystem faster (from COPR)
+trash-cli  # Move files and folders to the trash (replacement for macos-trash)
+
+# Graphics libraries
+glib2  # Core application library for C
+cairo  # Vector graphics library with cross-device output support
+
+# Code statistics
+cloc  # Statistics utility to count lines of code
+
+# Container tools
+podman  # Container runtimes (preferred on Fedora over Docker)
+podman-compose  # Isolated development environments using containers
+buildah  # Container image building
+
+# PHP development
+php  # General-purpose scripting language
+composer  # Dependency Manager for PHP
+
+# Data processing
+python3-csvkit  # Suite of command-line tools for working with CSV
+
+# JavaScript/TypeScript runtimes
+deno  # Secure runtime for JavaScript and TypeScript (from COPR)
+
+# Container inspection
+dive  # Tool for exploring each layer in a container image (from COPR)
+
+# Code formatting
+# dprint - install via cargo or direct download
+
+# Database tools
+duckdb  # Embeddable SQL OLAP Database Management System (from COPR)
+
+# Metadata tools
+perl-Image-ExifTool  # Perl lib for reading and writing EXIF metadata
+
+# Fuzzy finder
+fzf  # Command-line fuzzy finder written in Go
+
+# Git tools
+gh  # GitHub command-line tool (from COPR)
+git-delta  # Syntax-highlighting pager for git and diff output (from COPR)
+# git-town - install via direct download
+
+# Charm tools
+gum  # Tool for glamorous shell scripts (from COPR)
+
+# Text editors
+helix  # Post-modern modal text editor (from COPR)
+neovim  # Ambitious Vim-fork focused on extensibility and agility
+
+# HTTP tools
+httpie  # User-friendly cURL replacement (command-line HTTP client)
+
+# Static site generator
+hugo  # Configurable static site generator
+
+# Network tools
+nmap  # Port scanning utility for large networks
+
+# Python tools
+python3.12  # Python 3.12 interpreter
+pipx  # Execute binaries from Python packages in isolated environments
+python3-jupyterlab  # Interactive environments for writing and running code
+python3-fonttools  # Library for manipulating fonts
+
+# Database servers
+postgresql  # Object-relational database system
+# mysql or mariadb-server  # Relational database (uncomment preferred)
+redis  # Persistent key-value database
+
+# Cloud storage
+rclone  # Rsync for cloud storage
+
+# Network monitoring
+# sniffnet - install via cargo or Flatpak
+
+# Streaming
+streamlink  # CLI for extracting streams from various websites
+
+# Typesetting
+typst  # Markup-based typesetting system (from COPR)
+
+# Data processing
+yq  # Process YAML, JSON, XML, CSV from the CLI
+yt-dlp  # Feature-rich command-line audio/video downloader
+
+# Shell
+zsh  # Z shell
+zinit  # Flexible and fast Zsh plugin manager (install via script)
+
+# GPG
+gnupg2  # GNU Privacy Guard
+pinentry-gnome3  # Pinentry for GPG (GNOME integration)
+
+# Lazygit/Lazydocker
+lazygit  # Simple terminal UI for git commands (from COPR)
+# lazydocker - install via direct download
+
+# Mise (asdf replacement)
+mise  # Polyglot runtime manager (from COPR)
+
+# Ollama
+ollama  # Create, run, and share large language models (from COPR)
+
+# Terminal emulator
+ghostty  # Terminal emulator with GPU acceleration (from COPR)
+
+# Development
+# act - Run GitHub Actions locally (from COPR)
+
+# Tailscale
+tailscale  # Mesh VPN based on WireGuard


### PR DESCRIPTION
## Summary
- Adds `.config/dnf/` directory with Fedora package management equivalent to the Homebrew Brewfile
- Includes `install.sh` script that works like `brew bundle` - run it once to install all packages
- Maps all Homebrew formulae, casks, and taps to their Fedora equivalents (DNF, COPR, Flatpak)

## Structure
- `copr.txt` - COPR repositories to enable (similar to Homebrew taps)
- `packages.txt` - DNF packages (equivalent to Homebrew formulae)
- `flatpak.txt` - Flatpak packages (equivalent to Homebrew casks)
- `manual.txt` - Packages requiring manual installation (with install URLs)
- `install.sh` - Main install script with options for selective installation

## Usage
```bash
# Install everything
./install.sh

# Or selectively
./install.sh --copr       # Enable COPR repos only
./install.sh --packages   # Install DNF packages only
./install.sh --flatpak    # Install Flatpak packages only
./install.sh --manual     # Install manual packages only
./install.sh --dry-run    # Preview without installing
```

## Test plan
- [ ] Run `./install.sh --dry-run` to verify the script logic
- [ ] Test on Fedora 43 workstation
- [ ] Verify COPR repositories are enabled correctly
- [ ] Verify DNF packages install without errors
- [ ] Verify Flatpak packages install from Flathub
- [ ] Verify manual installation scripts work

🤖 Generated with [Claude Code](https://claude.com/claude-code)